### PR TITLE
Hotfix version - Fixes in v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[0.3.1] - 2025-09-06
+
+Hotfix release addressing a signing buffer bug and restoring backward compatibility.
+
+### Fixed
+
+- Fixed bug with small message buffer in sign function.
+
+### Changed
+
+- Reintroduced `microsui_sign_message` as **deprecated** for backward compatibility.
+
 ## \[0.3.0] - 2025-08-30
 
 - Added `microsui_http_post`, the first implementation of end-to-end transaction execution towards the Sui Network using HTTP(S) POST.

--- a/include/microsui/sign.h
+++ b/include/microsui/sign.h
@@ -8,4 +8,9 @@ int microsui_sign(uint8_t scheme, uint8_t sui_sig[97], const uint8_t* message, c
 
 int microsui_sign_ed25519(uint8_t sui_sig[97], const uint8_t* message, const size_t message_len, const uint8_t private_key[32]);
 
+/**
+ * @deprecated  Use microsui_sign() or microsui_sign_ed25519() instead.
+ */
+int microsui_sign_message(uint8_t sui_sig[97], const char* message_hex, const uint8_t private_key[32]);
+
 #endif

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "microsui-lib",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "MicroSui Library is a lightweight C library for embedded systems to interact with the Sui Network Blockchain",
     "keywords": "microsui, sui, blockchain, sui-network, walrus, cryptography, c-library",
     "repository": {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MicroSui
-version=0.3.0
+version=0.3.1
 author=Gustavo Belbruno
 maintainer=Gustavo Belbruno <gustavobelbruno@gmail.com>
 sentence=Pure C library for interacting with the Sui Network blockchain from microcontrollers.

--- a/src/microsui_core/sign.c
+++ b/src/microsui_core/sign.c
@@ -10,7 +10,7 @@
 #include "lib/compact25519/compact_ed25519.h"
 
 /**
- * @brief Sign a message digest using Ed25519 and produce a Sui-formatted signature.
+ * @brief Sign a Sui Transaction message using Ed25519 and produce a Sui-formatted signature.
  *
  * Builds the "message with intent" (prefix + tx bytes), digests it with BLAKE2b,
  * signs the digest with Ed25519, and encodes the result in the Sui signature
@@ -107,4 +107,32 @@ int microsui_sign(uint8_t scheme, uint8_t sui_sig[97], const uint8_t* message, c
         default:
             return -1; // Unsupported scheme
     }
+}
+
+
+///  DEPRECATED FUNCTIONS  ///
+/**
+ * @brief [DEPRECATED] Use microsui_sign() or microsui_sign_ed25519() instead.
+ *
+ * @deprecated This function is kept only for backward compatibility.
+ *             Please use microsui_sign() or microsui_sign_ed25519(),
+ *             which provide better compatibility and performance.
+ *
+ * @param[out] sui_sig       Output buffer for the Sui signature (must be 97 bytes).
+ * @param[in]  message_hex   Null-terminated string containing the full serialized tx message in hexa form.
+ * @param[in]  private_key   32-byte Ed25519 private key seed.
+ *
+ * @return 0 on success, negative value on error.
+ */
+int microsui_sign_message(uint8_t sui_sig[97], const char* message_hex, const uint8_t private_key[32]) {
+    // Convert the hex message to binary bytes
+    size_t msg_len = strlen(message_hex) / 2;  // 2 hex chars = 1 byte
+    uint8_t* message = (uint8_t*)malloc(msg_len);
+    hex_to_bytes(message_hex, message, msg_len);
+
+    // Call the new ED25519 sign function version
+    int res = microsui_sign_ed25519(sui_sig, message, msg_len, private_key);
+
+    free(message);
+    return res;
 }

--- a/src/microsui_core/sign.h
+++ b/src/microsui_core/sign.h
@@ -8,4 +8,9 @@ int microsui_sign(uint8_t scheme, uint8_t sui_sig[97], const uint8_t* message, c
 
 int microsui_sign_ed25519(uint8_t sui_sig[97], const uint8_t* message, const size_t message_len, const uint8_t private_key[32]);
 
+/**
+ * @deprecated  Use microsui_sign() or microsui_sign_ed25519() instead.
+ */
+int microsui_sign_message(uint8_t sui_sig[97], const char* message_hex, const uint8_t private_key[32]);
+
 #endif


### PR DESCRIPTION
- Fixed bug with small message buffer in sign function
- Reintroduce microsui_sign_message as deprecated (for backward compatibility).
- New version v0.3.1